### PR TITLE
Small copy update to README 

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -42,7 +42,7 @@ brew install --cask warp
 
 ## Changelog and Releases
 
-We try to release an update every Warp Wednesday. See our [changelog (release notes).](https://docs.warp.dev/help/changelog)
+We try to release an update weekly, typically on Thursdays. See our [changelog (release notes).](https://docs.warp.dev/help/changelog)
 
 ## Issues, Bugs, and Feature Requests
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -42,7 +42,7 @@ brew install --cask warp
 
 ## Changelog and Releases
 
-We try to release an update weekly, typically on Thursdays. See our [changelog (release notes).](https://docs.warp.dev/help/changelog)
+We try to release an update weekly, typically on Thursdays. Read our [changelog (release notes).](https://docs.warp.dev/help/changelog)
 
 ## Issues, Bugs, and Feature Requests
 


### PR DESCRIPTION
Updates the description of our release cadence to match what's published on docs.warp.dev

Uses slightly more inclusive language "read" instead of "see" where relevant